### PR TITLE
Introduce MySQL dbscript for RDBMS coordination

### DIFF
--- a/modules/broker-core/src/main/resources/dbscripts/mysql-mb.sql
+++ b/modules/broker-core/src/main/resources/dbscripts/mysql-mb.sql
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- WSO2 Message Broker MySQL Database Schema --
+
+-- Start of RDBMS based Coordinator Election Tables  --
+
+CREATE TABLE IF NOT EXISTS MB_COORDINATOR_HEARTBEAT (
+                        ANCHOR INT NOT NULL,
+                        NODE_ID VARCHAR(512) NOT NULL,
+                        LAST_HEARTBEAT BIGINT NOT NULL,
+                        PRIMARY KEY (ANCHOR)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS MB_NODE_HEARTBEAT (
+                        NODE_ID VARCHAR(512) NOT NULL,
+                        LAST_HEARTBEAT BIGINT NOT NULL,
+                        IS_NEW_NODE TINYINT NOT NULL,
+                        PRIMARY KEY (NODE_ID)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- End of RDBMS based Coordinator Election Tables  --

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>wso2-scm-server</project.scm.id>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
-        <andes.version>3.2.19</andes.version>
+        <andes.version>3.2.36</andes.version>
         <geronimo-jms_1.1_spec.version>1.1.0.wso2v1</geronimo-jms_1.1_spec.version>
         <javacc.plugin.version>2.6</javacc.plugin.version>
         <maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> Introduce the MySQL dbscript for RDBMS based coordinator election.

## Goals
> Facilitate creation of the tables required for RDBMS based coordinator election.

## Approach
> Introduce the MySQL script for the creation of the MB_COORDINATOR_HEARTBEAT, MB_NODE_HEARTBEAT and MB_MEMBERSHIP tables required for the RDBMS based coordinator election implementation.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A - would be part of the initial creation of the database tables required by the broker

## Training
> N/A

## Certification
> N/A - introduces db scripts

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> #74 

## Migrations (if applicable)
> N/A

## Test environment
> MySQL
 
## Learning
> N/A