### PR TITLE
Fix Derby database relative path issue

### DIFF
--- a/modules/launcher/src/main/assembly/assembly.xml
+++ b/modules/launcher/src/main/assembly/assembly.xml
@@ -36,7 +36,7 @@
             <directory>src/main/resources/</directory>
             <outputDirectory>bin</outputDirectory>
             <includes>
-                <include>broker</include>
+                <include>broker.sh</include>
                 <include>broker.bat</include>
             </includes>
             <fileMode>755</fileMode>

--- a/modules/launcher/src/main/resources/broker.sh
+++ b/modules/launcher/src/main/resources/broker.sh
@@ -101,6 +101,7 @@ $JAVACMD \
     $JAVA_OPTS \
     -classpath "$MESSAGE_BROKER_CLASSPATH" \
     -Dfile.encoding=UTF8 \
+    -Dderby.system.home="$MESSAGE_BROKER_HOME" \
     -Dmessage.broker.home="$MESSAGE_BROKER_HOME" \
     -Dlog4j.configuration="file:$MESSAGE_BROKER_HOME/conf/log4j.properties" \
     -Dbroker.config="$MESSAGE_BROKER_HOME/conf/broker.yaml" \

--- a/modules/launcher/src/main/resources/broker.yaml
+++ b/modules/launcher/src/main/resources/broker.yaml
@@ -16,7 +16,7 @@
 
 broker:
  dataSource:
-  url: jdbc:derby:../database
+  url: jdbc:derby:database
   user: root
   password: root
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves #127 
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Set derby database path correctly irrespective of the location the broker startup script is executed from
 
## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Use derby.system.home property to set broker home as the derby system home.
