### PR TITLE
Implement syncing on fail-over

### DIFF
--- a/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/Server.java
+++ b/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/Server.java
@@ -184,6 +184,10 @@ public class Server {
         }
     }
 
+    public void shutdown() throws InterruptedException {
+        serverHelper.shutdown();
+    }
+
     /**
      * Method to close the channels.
      */
@@ -236,6 +240,7 @@ public class Server {
     }
 
     private class ServerHelper {
+
         public void start() throws InterruptedException, CertificateException, UnrecoverableKeyException,
                 NoSuchAlgorithmException, KeyStoreException, KeyManagementException,
                 IOException {
@@ -247,6 +252,11 @@ public class Server {
                 sslServerChannel = sslSocketFuture.channel();
             }
         }
+
+        public void shutdown() throws InterruptedException {
+            stop();
+        }
+
     }
 
     private class HaEnabledServerHelper extends ServerHelper implements HaListener {
@@ -267,6 +277,12 @@ public class Server {
                 return;
             }
             super.start();
+        }
+
+        @Override
+        public void shutdown() throws InterruptedException {
+            haStrategy.unregisterListener(basicHaListener);
+            super.shutdown();
         }
 
         /**

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
@@ -216,6 +216,11 @@ public final class Broker {
          * {@inheritDoc}
          */
         public void activate() {
+            try {
+                messagingEngine.reloadOnBecomingActive();
+            } catch (BrokerException e) {
+                LOGGER.error("Error on loading data from the database on becoming active ", e);
+            }
             startMessageDeliveryOnBecomingActive();
             LOGGER.info("Broker mode changed from PASSIVE to ACTIVE");
         }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
@@ -165,6 +165,10 @@ public final class Broker {
         messagingEngine.stopMessageDelivery();
     }
 
+    public void shutdown() {
+        brokerHelper.shutdown();
+    }
+
     public long getNextMessageId() {
         return messagingEngine.getNextMessageId();
     }
@@ -192,6 +196,10 @@ public final class Broker {
             messagingEngine.startMessageDelivery();
         }
 
+        public void shutdown() {
+            stopMessageDelivery();
+        }
+
     }
 
     private class HaEnabledBrokerHelper extends BrokerHelper implements HaListener {
@@ -210,6 +218,12 @@ public final class Broker {
                 return;
             }
             super.startMessageDelivery();
+        }
+
+        @Override
+        public void shutdown() {
+            haStrategy.unregisterListener(basicHaListener);
+            super.shutdown();
         }
 
         /**

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/ExchangeRegistry.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/ExchangeRegistry.java
@@ -134,6 +134,17 @@ public final class ExchangeRegistry {
     }
 
     /**
+     * Method to reload exchanges and bindings from the database on becoming the active node.
+     *
+     * @param queueRegistry the queue registry object
+     * @throws BrokerException if an error occurs retrieving exchanges/bindings from the database
+     */
+    void reloadExchangesOnBecomingActive(QueueRegistry queueRegistry) throws BrokerException {
+        exchangeMap.clear();
+        retrieveFromStore(queueRegistry);
+    }
+
+    /**
      * Factory class to create the relevant exchange for the requested exchange type.
      */
     public static class ExchangeFactory {

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/MessagingEngine.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/MessagingEngine.java
@@ -353,4 +353,16 @@ final class MessagingEngine {
     public QueueHandler getQueue(String queueName) {
         return queueRegistry.getQueueHandler(queueName);
     }
+
+    /**
+     * Method to reload data from the database on becoming the active node.
+     *
+     * @throws BrokerException if an error occurs retrieving queue and exchange data from the database
+     */
+    void reloadOnBecomingActive() throws BrokerException {
+        sharedMessageStore.clearPendingMessages();
+        queueRegistry.reloadQueuesOnBecomingActive();
+        exchangeRegistry.reloadExchangesOnBecomingActive(queueRegistry);
+    }
+
 }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/QueueRegistry.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/QueueRegistry.java
@@ -108,4 +108,14 @@ public final class QueueRegistry {
     public Collection<QueueHandler> getAllQueues() {
         return queueHandlerMap.values();
     }
+
+    /**
+     * Method to reload queues on becoming the active node.
+     *
+     * @throws BrokerException if an error occurs loading messages from the database
+     */
+    void reloadQueuesOnBecomingActive() throws BrokerException {
+        queueHandlerMap.clear();
+        retrieveQueuesFromDao();
+    }
 }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/SharedMessageStore.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/SharedMessageStore.java
@@ -120,4 +120,12 @@ public class SharedMessageStore {
     public Collection<Message> readStoredMessages(String queueName) throws BrokerException {
         return messageDao.readAll(queueName);
     }
+
+    /**
+     * Method to clear all pending messages.
+     */
+    public void clearPendingMessages() {
+        pendingMessages.clear();
+    }
+
 }

--- a/modules/broker-rest-runner/src/main/java/org/wso2/broker/rest/BrokerRestServer.java
+++ b/modules/broker-rest-runner/src/main/java/org/wso2/broker/rest/BrokerRestServer.java
@@ -75,11 +75,19 @@ public class BrokerRestServer {
         LOGGER.info("Broker admin service stopped.");
     }
 
+    public void shutdown() {
+        brokerRestRunnerHelper.shutdown();
+    }
+
     private class BrokerRestRunnerHelper {
 
         public void start() {
             microservicesRunner.start();
             LOGGER.info("Broker admin service started on port {}", port);
+        }
+
+        public void shutdown() {
+            stop();
         }
 
     }
@@ -100,6 +108,12 @@ public class BrokerRestServer {
                 return;
             }
             super.start();
+        }
+
+        @Override
+        public void shutdown() {
+            haStrategy.unregisterListener(basicHaListener);
+            super.shutdown();
         }
 
         /**

--- a/modules/integration/src/test/java/org/wso2/messaging/integration/util/Node.java
+++ b/modules/integration/src/test/java/org/wso2/messaging/integration/util/Node.java
@@ -58,9 +58,16 @@ public class Node {
 
     private HaStrategy haStrategy;
 
+    private String hostname;
+
+    private String port;
+
     public Node(String hostname, String port, String sslPort, String restPort, String adminUsername,
                 String adminPassword, StartupContext startupContext, TestConfigProvider configProvider)
             throws Exception {
+
+        this.hostname = hostname;
+        this.port = port;
 
         BrokerConfiguration brokerConfiguration = new BrokerConfiguration();
         BrokerConfiguration.AuthenticationConfiguration authenticationConfiguration = new BrokerConfiguration
@@ -140,4 +147,11 @@ public class Node {
         return haStrategy.isActiveNode();
     }
 
+    public String getHostname() {
+        return hostname;
+    }
+
+    public String getPort() {
+        return port;
+    }
 }

--- a/modules/launcher/src/main/java/org/wso2/broker/Main.java
+++ b/modules/launcher/src/main/java/org/wso2/broker/Main.java
@@ -175,18 +175,18 @@ public class Main {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             synchronized (LOCK) {
                 shutdownHookTriggered = true;
-                brokerRestServer.stop();
-                if (haStrategy != null) {
-                    haStrategy.stop();
-                }
+                brokerRestServer.shutdown();
                 try {
-                    server.stop();
+                    server.shutdown();
                     server.awaitServerClose();
                 } catch (InterruptedException e) {
                     LOGGER.warn("Error stopping transport on shut down {}", e);
                 }
-                broker.stopMessageDelivery();
+                broker.shutdown();
                 metricService.stop();
+                if (haStrategy != null) {
+                    haStrategy.stop();
+                }
                 LOCK.notifyAll();
             }
         }));


### PR DESCRIPTION
## Purpose
Introduce reloading queue/exchange/binding data from the database on fail-over: Resolves #165 

## Goals
Make durable queues and relevant messages available to the new active node, once fail-over occurs.

## Approach
Clear existing data/objects and reload relevant data from database, on notification of becoming the active node.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
79%
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> #114 

## Migrations (if applicable)
N/A

## Test environment
MySQL
 
## Learning
N/A