### PR TITLE
Add JMS selectors user documentation

### DIFF
--- a/docs/user-doc-index.md
+++ b/docs/user-doc-index.md
@@ -4,3 +4,4 @@
 - [Changing the Default MB Database](user/database-setup-guide.md)
 - [Configuring High Availability for the Broker](user/configuring-high-availability.md)
 - [Changing the Default Security Settings](user/security-settings-guide.md)
+- [Using JMS selectors](user/jms-selector-guide.md)

--- a/docs/user/jms-selector-guide.md
+++ b/docs/user/jms-selector-guide.md
@@ -1,0 +1,17 @@
+# JMS Selectors
+
+This broker is written based on AMQP broker semantics. In addition, to AMQP broker semantics 
+following JMS selector functionalities are supported as well.
+
+1. __x-filter-jms-selector__ header is used to define the selector expression.
+    When binding a queue to an exchange above additional header can be provided with a
+    valid JMS selector expression to enable message filtering.  
+2. Only the topic exchange supports JMS message selectors. 
+3. Subset of JMS selector grammar is supported. At the moment JMS equality
+   operator with string, integer and float values are supported.
+    ```iso92-sql
+    CorrelationId = 'a234df34'
+    eventName = 'logging'
+    ```
+    
+ 


### PR DESCRIPTION
## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

User documentation added for JMS selectors.
relates #66 
relates #48 
