### PR TITLE
Durable queue message spilling

### DIFF
--- a/docs/user/configure.md
+++ b/docs/user/configure.md
@@ -15,6 +15,7 @@ These configurations are defined under the namespace `wso2.broker`.
 
 | Config                      | Default Value                          | Description                                   |
 |-----------------------------| ---------------------------------------|-----------------------------------------------|
+| queueInMemoryCacheLimit     | 10000                                  | Maximum number of messages cached in-memory for faster delivery. Increasing this number can result in better throughput while increasing the memory consumption. | 
 | datasource:url              | jdbc:derby:database                    | Database URL.                                 |
 | database:user               | root                                   | Database username                             |
 | database:password           | root                                   | Database password.                            |

--- a/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/AmqpConsumer.java
+++ b/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/AmqpConsumer.java
@@ -77,7 +77,7 @@ public class AmqpConsumer extends Consumer {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Adding message to AMQP Netty outbound; messageId: {}, consumerTag: {}, queueName: {}",
-                         message.getMetadata().getInternalId(),
+                         message.getInternalId(),
                          consumerTag,
                          queueName);
         }

--- a/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/codec/AmqpChannel.java
+++ b/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/codec/AmqpChannel.java
@@ -284,7 +284,7 @@ public class AmqpChannel {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Redelivery count is {} for message {}",
                          redeliveryCount,
-                         message.getMetadata().getInternalId());
+                         message.getInternalId());
         }
         if (redeliveryCount <= maxRedeliveryCount) {
             broker.requeue(queueName, message);

--- a/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/codec/InMemoryMessageAggregator.java
+++ b/modules/broker-amqp/src/main/java/org/wso2/broker/amqp/codec/InMemoryMessageAggregator.java
@@ -75,22 +75,22 @@ public class InMemoryMessageAggregator {
      */
     public void headerFrameReceived(FieldTable headers, FieldTable properties, long payloadSize) {
         long messageId = broker.getNextMessageId();
-        Metadata metadata = new Metadata(messageId, routingKey, exchangeName, payloadSize);
+        Metadata metadata = new Metadata(routingKey, exchangeName, payloadSize);
         metadata.setProperties(properties);
         metadata.setHeaders(headers);
-        message = new Message(metadata);
-        trace(metadata);
+        message = new Message(messageId, metadata);
+        trace(message);
     }
 
-    private void trace(Metadata metadata) {
+    private void trace(Message message) {
         if (MessageTracer.isTraceEnabled()) {
             List<TraceField> traceFields = new ArrayList<>();
-            FieldValue fieldValue = metadata.getProperty(Metadata.CORRELATION_ID);
+            FieldValue fieldValue = message.getMetadata().getProperty(Metadata.CORRELATION_ID);
             if (Objects.nonNull(fieldValue)) {
                 TraceField field = new TraceField(CORRELATION_ID_FIELD_NAME, fieldValue.getValue());
                 traceFields.add(field);
             }
-            MessageTracer.trace(metadata, INCOMING_MESSAGE_MAPPED, traceFields);
+            MessageTracer.trace(message, INCOMING_MESSAGE_MAPPED, traceFields);
         }
     }
 

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/Broker.java
@@ -21,6 +21,7 @@ package org.wso2.broker.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.broker.common.BrokerConfigProvider;
 import org.wso2.broker.common.ResourceNotFoundException;
 import org.wso2.broker.common.StartupContext;
 import org.wso2.broker.common.ValidationException;
@@ -28,6 +29,7 @@ import org.wso2.broker.common.data.types.FieldTable;
 import org.wso2.broker.coordination.BasicHaListener;
 import org.wso2.broker.coordination.HaListener;
 import org.wso2.broker.coordination.HaStrategy;
+import org.wso2.broker.core.configuration.BrokerConfiguration;
 import org.wso2.broker.core.metrics.BrokerMetricManager;
 import org.wso2.broker.core.metrics.DefaultBrokerMetricManager;
 import org.wso2.broker.core.metrics.NullBrokerMetricManager;
@@ -70,8 +72,11 @@ public final class Broker {
             metricManager = new NullBrokerMetricManager();
         }
 
+        BrokerConfigProvider configProvider = startupContext.getService(BrokerConfigProvider.class);
+        BrokerConfiguration configuration = configProvider.getConfigurationObject(BrokerConfiguration.NAMESPACE,
+                                                                                        BrokerConfiguration.class);
         DataSource dataSource = startupContext.getService(DataSource.class);
-        StoreFactory storeFactory = new StoreFactory(dataSource, metricManager);
+        StoreFactory storeFactory = new StoreFactory(dataSource, metricManager, configuration);
         this.messagingEngine = new MessagingEngine(storeFactory, metricManager);
         BrokerServiceRunner serviceRunner = startupContext.getService(BrokerServiceRunner.class);
         serviceRunner.deploy(new QueuesApi(this), new ExchangesApi(this));

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/Message.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/Message.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -138,7 +139,12 @@ public class Message {
 
     @Override
     public String toString() {
-        return metadata.toString();
+
+        if (Objects.isNull(metadata)) {
+            return "Bare message";
+        } else {
+            return metadata.toString();
+        }
     }
 
     public void setMetadata(Metadata metadata) {

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/MessagingEngine.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/MessagingEngine.java
@@ -186,7 +186,7 @@ final class MessagingEngine {
                     LOGGER.info("Dropping message since no queues found for routing key " + routingKey + " in "
                                         + exchange);
                     message.release();
-                    MessageTracer.trace(metadata, MessageTracer.NO_ROUTES);
+                    MessageTracer.trace(message, MessageTracer.NO_ROUTES);
                 } else {
                     try {
                         sharedMessageStore.add(message);
@@ -202,14 +202,14 @@ final class MessagingEngine {
                         }
                         publishToQueues(message, uniqueQueues);
                     } finally {
-                        sharedMessageStore.flush(metadata.getInternalId());
+                        sharedMessageStore.flush(message.getInternalId());
                         // Release the original message. Shallow copies are distributed
                         message.release(); // TODO: avoid shallow copying when there is only one binding
                     }
                 }
             } else {
                 message.release();
-                MessageTracer.trace(metadata, MessageTracer.UNKNOWN_EXCHANGE);
+                MessageTracer.trace(message, MessageTracer.UNKNOWN_EXCHANGE);
                 throw new BrokerException("Message publish failed. Unknown exchange: " + metadata.getExchangeName());
             }
         } finally {
@@ -222,7 +222,7 @@ final class MessagingEngine {
         if (uniqueQueues.isEmpty()) {
             LOGGER.info("Dropping message since message didn't have any routes to {}",
                         message.getMetadata().getRoutingKey());
-            MessageTracer.trace(message.getMetadata(), MessageTracer.NO_ROUTES);
+            MessageTracer.trace(message, MessageTracer.NO_ROUTES);
             return;
         }
 

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/Metadata.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/Metadata.java
@@ -52,11 +52,6 @@ public class Metadata {
     public static final int NON_PERSISTENT_MESSAGE = 1;
 
     /**
-     * Unique id of the message.
-     */
-    private final long internalId;
-
-    /**
      * Key value used by the router (exchange) to identify the relevant queue(s) for this message.
      */
     private final String routingKey;
@@ -75,17 +70,12 @@ public class Metadata {
 
     private FieldTable headers;
 
-    public Metadata(long internalId, String routingKey, String exchangeName, long contentLength) {
-        this.internalId = internalId;
+    public Metadata(String routingKey, String exchangeName, long contentLength) {
         this.routingKey = routingKey;
         this.exchangeName = exchangeName;
         this.contentLength = contentLength;
         this.properties = FieldTable.EMPTY_TABLE;
         this.headers = FieldTable.EMPTY_TABLE;
-    }
-
-    public long getInternalId() {
-        return internalId;
     }
 
     public String getRoutingKey() {
@@ -101,12 +91,12 @@ public class Metadata {
     }
 
     public Metadata shallowCopy() {
-        Metadata metadata = shallowCopyWith(internalId, routingKey, exchangeName);
+        Metadata metadata = shallowCopyWith(routingKey, exchangeName);
         return metadata;
     }
 
-    public Metadata shallowCopyWith(long internalId, String routingKey, String exchangeName) {
-        Metadata metadata = new Metadata(internalId, routingKey, exchangeName, contentLength);
+    public Metadata shallowCopyWith(String routingKey, String exchangeName) {
+        Metadata metadata = new Metadata(routingKey, exchangeName, contentLength);
         metadata.properties = properties;
         metadata.headers = headers;
         return metadata;
@@ -116,8 +106,7 @@ public class Metadata {
     @Override
     public String toString() {
         return "Metadata{"
-                + "internalId=" + internalId
-                + ", routingKey='" + routingKey + '\''
+                + "routingKey='" + routingKey + '\''
                 + ", exchangeName='" + exchangeName + '\''
                 + ", contentLength=" + contentLength
                 + ", messageId= " + properties.getValue(MESSAGE_ID) + '\''

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/QueueHandler.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/QueueHandler.java
@@ -180,7 +180,7 @@ public final class QueueHandler {
      * @return True if the queue doesn't contain any {@link Message} objects
      */
     boolean isEmpty() {
-        return (queue.size() + redeliveryQueue.size()) == 0;
+        return (queue.size()) == 0;
     }
 
     /**
@@ -189,7 +189,7 @@ public final class QueueHandler {
      * @return Number of {@link Message} objects in the queue.
      */
     public int size() {
-        return queue.size() + redeliveryQueue.size();
+        return queue.size();
     }
 
     /**

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/QueueHandlerFactory.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/QueueHandlerFactory.java
@@ -19,9 +19,11 @@
 
 package org.wso2.broker.core;
 
+import org.wso2.broker.core.configuration.BrokerConfiguration;
 import org.wso2.broker.core.metrics.BrokerMetricManager;
 import org.wso2.broker.core.queue.DbBackedQueueImpl;
 import org.wso2.broker.core.queue.MemQueueImpl;
+import org.wso2.broker.core.queue.QueueBufferFactory;
 import org.wso2.broker.core.store.SharedMessageStore;
 
 /**
@@ -30,10 +32,13 @@ import org.wso2.broker.core.store.SharedMessageStore;
 public class QueueHandlerFactory {
     private final SharedMessageStore sharedMessageStore;
     private final BrokerMetricManager metricManager;
+    private QueueBufferFactory queueBufferFactory;
 
-    public QueueHandlerFactory(SharedMessageStore sharedMessageStore, BrokerMetricManager metricManager) {
+    public QueueHandlerFactory(SharedMessageStore sharedMessageStore, BrokerMetricManager metricManager,
+            BrokerConfiguration configuration) {
         this.sharedMessageStore = sharedMessageStore;
         this.metricManager = metricManager;
+        queueBufferFactory = new QueueBufferFactory(configuration);
     }
 
     /**
@@ -45,7 +50,7 @@ public class QueueHandlerFactory {
      * @throws BrokerException if cannot create queue handler
      */
     QueueHandler createDurableQueueHandler(String queueName, boolean autoDelete) throws BrokerException {
-        Queue queue = new DbBackedQueueImpl(queueName, autoDelete, sharedMessageStore);
+        Queue queue = new DbBackedQueueImpl(queueName, autoDelete, sharedMessageStore, queueBufferFactory);
         return new QueueHandler(queue, metricManager);
     }
 

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/configuration/BrokerConfiguration.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/configuration/BrokerConfiguration.java
@@ -38,7 +38,20 @@ public class BrokerConfiguration {
      */
     public static final String SYSTEM_PARAM_BROKER_CONFIG_FILE = "broker.config";
 
+    private String queueInMemoryCacheLimit = "10000";
+
     private DataSourceConfiguration dataSource;
+
+    /**
+     * Getter for queueInMemoryCacheLimit.
+     */
+    public String getQueueInMemoryCacheLimit() {
+        return queueInMemoryCacheLimit;
+    }
+
+    public void setQueueInMemoryCacheLimit(String queueInMemoryCacheLimit) {
+        this.queueInMemoryCacheLimit = queueInMemoryCacheLimit;
+    }
 
     public DataSourceConfiguration getDataSource() {
         return dataSource;

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/queue/DbBackedQueueImpl.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/queue/DbBackedQueueImpl.java
@@ -31,22 +31,15 @@ import java.util.Collection;
  * Database backed queue implementation.
  */
 public class DbBackedQueueImpl extends Queue {
-
-    /**
-     * Maximum number of message data held in memory.
-     * TODO: This should be configurable
-     */
-    private static final int DEFAULT_QUEUE_BUFFER_SIZE = 1000;
-
     private final SharedMessageStore sharedMessageStore;
 
     private final QueueBuffer buffer;
 
     public DbBackedQueueImpl(String queueName, boolean autoDelete,
-                      SharedMessageStore sharedMessageStore) throws BrokerException {
+            SharedMessageStore sharedMessageStore, QueueBufferFactory queueBufferFactory) throws BrokerException {
         super(queueName, true, autoDelete);
         this.sharedMessageStore = sharedMessageStore;
-        buffer = new QueueBuffer(DEFAULT_QUEUE_BUFFER_SIZE, sharedMessageStore::readData);
+        buffer = queueBufferFactory.createBuffer(sharedMessageStore::readData);
         Collection<Message> messages = sharedMessageStore.readStoredMessages(queueName);
         buffer.addAll(messages);
     }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/queue/DbBackedQueueImpl.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/queue/DbBackedQueueImpl.java
@@ -19,8 +19,6 @@
 
 package org.wso2.broker.core.queue;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.broker.core.BrokerException;
 import org.wso2.broker.core.Message;
 import org.wso2.broker.core.Metadata;
@@ -33,9 +31,11 @@ import java.util.Collection;
  * Database backed queue implementation.
  */
 public class DbBackedQueueImpl extends Queue {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DbBackedQueueImpl.class);
 
-
+    /**
+     * Maximum number of message data held in memory.
+     * TODO: This should be configurable
+     */
     private static final int DEFAULT_QUEUE_BUFFER_SIZE = 1000;
 
     private final SharedMessageStore sharedMessageStore;
@@ -72,8 +72,7 @@ public class DbBackedQueueImpl extends Queue {
 
     @Override
     public Message dequeue() {
-        Message firstDeliverable = buffer.getFirstDeliverable();
-        return firstDeliverable;
+        return buffer.getFirstDeliverable();
     }
 
     @Override

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/queue/QueueBuffer.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/queue/QueueBuffer.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.broker.core.queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.broker.core.Message;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Used to track messages for the queue.
+ */
+public class QueueBuffer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(QueueBuffer.class);
+
+    private AtomicInteger size = new AtomicInteger(0);
+
+    /**
+     * Pointer to first node.
+     * Invariant: (first == null && last == null) ||
+     *            (first.prev == null && first.item != null)
+     */
+    private Node first;
+
+    /**
+     * Pointer to first deliverable node.
+     * Invariant: (first == null && last == null) ||
+     *            (first.prev == null && first.item != null)
+     */
+    private Node firstDeliverable;
+
+    /**
+     * Pointer to last deliverable node.
+     */
+    private Node firstUndeliverable;
+
+    /**
+     * Pointer to last node.
+     * Invariant: (first == null && last == null) ||
+     *            (last.next == null && last.item != null)
+     */
+    private Node last;
+
+    /**
+     * Used to fast lookup the node for a message ID
+     */
+    private Map<Long, Node> keyMap = new HashMap<>();
+
+    /**
+     * Appends the specified message to the end of this list.
+     *
+     * @param message message to be appended to this list
+     */
+    public synchronized void add(Message message) {
+        linkLast(message);
+    }
+
+    /**
+     * Links newMessage as last element.
+     */
+    private void linkLast(Message newMessage) {
+        final Node previousLast = last;
+        final Node newNode = new Node(previousLast, newMessage, null);
+        last = newNode;
+        keyMap.put(newMessage.getMetadata().getInternalId(), newNode);
+
+        if (previousLast == null) {
+            first = newNode;
+            firstDeliverable = newNode;
+        } else {
+            previousLast.next = newNode;
+        }
+
+        size.incrementAndGet();
+    }
+
+    public synchronized void remove(Message message) {
+        long messageId = message.getMetadata().getInternalId();
+        Node node = keyMap.remove(messageId);
+        if (node == null) {
+            LOGGER.warn("Asked to remove a non existing message with ID {}", messageId);
+            return;
+        }
+
+        unlink(node);
+    }
+
+
+    /**
+     * Unlinks non-null node.
+     */
+    private void unlink(Node node) {
+        final Node next = node.next;
+        final Node prev = node.prev;
+
+        // if prev is null we are removing the first element
+        if (prev == null) {
+            first = next;
+        } else {
+            prev.next = next;
+            node.prev = null;
+        }
+
+        // if next is null we are removing the last element
+        if (next == null) {
+            last = prev;
+        } else {
+            next.prev = prev;
+            node.next = null;
+        }
+
+        node.item = null;
+        size.decrementAndGet();
+    }
+
+    public int size() {
+        return size.get();
+    }
+
+    public synchronized Message getFirstDeliverable() {
+        Node deliverableNode = firstDeliverable;
+
+        if (deliverableNode != firstUndeliverable) {
+            firstDeliverable = deliverableNode.next;
+            return deliverableNode.item;
+        } else  {
+            return null;
+        }
+    }
+
+    public void addAll(Collection<Message> messages) {
+        for (Message message : messages) {
+            add(message);
+        }
+    }
+
+    private static class Node {
+        Message item;
+        Node next;
+        Node prev;
+
+        Node(Node prev, Message element, Node next) {
+            this.item = element;
+            this.next = next;
+            this.prev = prev;
+        }
+    }
+}

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/queue/QueueBufferFactory.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/queue/QueueBufferFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.broker.core.queue;
+
+import org.wso2.broker.core.configuration.BrokerConfiguration;
+/**
+ * Factory class for {@link QueueBuffer}.
+ */
+public class QueueBufferFactory {
+    private int inMemoryCacheLimit;
+
+    public QueueBufferFactory(BrokerConfiguration configuration) {
+        inMemoryCacheLimit = Integer.parseInt(configuration.getQueueInMemoryCacheLimit());
+    }
+
+    public QueueBuffer createBuffer(QueueBuffer.MessageReader messageReader) {
+        return new QueueBuffer(inMemoryCacheLimit, messageReader);
+    }
+}

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/DbEventMatcher.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/DbEventMatcher.java
@@ -61,7 +61,7 @@ public class DbEventMatcher implements EventHandler<DbOperation> {
 
         switch (event.getType()) {
             case INSERT_MESSAGE:
-                insertMap.put(event.getMessage().getMetadata().getInternalId(), event);
+                insertMap.put(event.getMessage().getInternalId(), event);
                 break;
             case DELETE_MESSAGE:
                 long internalId = event.getMessageId();
@@ -72,6 +72,7 @@ public class DbEventMatcher implements EventHandler<DbOperation> {
                 detachMap.computeIfAbsent(event.getMessageId(), k -> new ArrayList<>())
                          .add(event);
                 break;
+            case READ_MSG_DATA:
             case NO_OP:
                 break;
             default:

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/FinalEventHandler.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/FinalEventHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.broker.core.store;
+
+import com.lmax.disruptor.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class initiates database operations through disruptor
+ */
+public class FinalEventHandler implements EventHandler<DbOperation> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FinalEventHandler.class);
+
+    @Override
+    public void onEvent(DbOperation event, long sequence, boolean endOfBatch) {
+        try {
+            switch (event.getType()) {
+                case READ_MSG_DATA:
+                    event.getQueueBuffer().markMessageFilled(event.getBareMessage());
+                    break;
+                case INSERT_MESSAGE:
+                case DELETE_MESSAGE:
+                case DETACH_MSG_FROM_QUEUE:
+                case NO_OP:
+                    break;
+                default:
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.error("Unknown event type " + event.getType());
+                    }
+            }
+        } finally {
+            event.clear();
+        }
+    }
+
+}

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/StoreFactory.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/StoreFactory.java
@@ -23,6 +23,7 @@ import org.wso2.broker.core.BrokerException;
 import org.wso2.broker.core.ExchangeRegistry;
 import org.wso2.broker.core.QueueHandlerFactory;
 import org.wso2.broker.core.QueueRegistry;
+import org.wso2.broker.core.configuration.BrokerConfiguration;
 import org.wso2.broker.core.metrics.BrokerMetricManager;
 import org.wso2.broker.core.store.dao.impl.DaoFactory;
 
@@ -35,10 +36,12 @@ public class StoreFactory {
 
     private final DaoFactory daoFactory;
     private final BrokerMetricManager metricManager;
+    private final BrokerConfiguration configuration;
 
-    public StoreFactory(DataSource dataSource, BrokerMetricManager metricManager) {
+    public StoreFactory(DataSource dataSource, BrokerMetricManager metricManager, BrokerConfiguration configuration) {
         daoFactory = new DaoFactory(dataSource, metricManager);
         this.metricManager = metricManager;
+        this.configuration = configuration;
     }
 
     /**
@@ -62,6 +65,7 @@ public class StoreFactory {
      * @return QueueRegistry object
      */
     public QueueRegistry getQueueRegistry(SharedMessageStore messageStore) throws BrokerException {
-        return new QueueRegistry(daoFactory.createQueueDao(), new QueueHandlerFactory(messageStore, metricManager));
+        return new QueueRegistry(daoFactory.createQueueDao(),
+                                 new QueueHandlerFactory(messageStore, metricManager, configuration));
     }
 }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/MessageDao.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/MessageDao.java
@@ -5,6 +5,7 @@ import org.wso2.broker.core.Message;
 import org.wso2.broker.core.store.DbOperation;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Defines a functionality required for manipulating messages in persistent storage.
@@ -35,8 +36,15 @@ public interface MessageDao {
 
     /**
      * Retrieve all messages from a given queue.
+     *
      * @param queueName name of the queue.
      */
     Collection<Message> readAll(String queueName) throws BrokerException;
 
+    /**
+     * Read message data for given messages.
+     *
+     * @param readList list of messages.
+     */
+    Collection<Message> read(Map<Long, Message> readList) throws BrokerException;
 }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/impl/MessageCrudOperationsDao.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/impl/MessageCrudOperationsDao.java
@@ -174,14 +174,10 @@ class MessageCrudOperationsDao extends BaseDao {
         }
     }
 
-    @SuppressFBWarnings(
-            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-            justification = "Return value of context.stop() is not required.")
     public Collection<Message> readAll(Connection connection, String queueName) throws BrokerException {
         Map<Long, Message> messageMap = new HashMap<>();
-        Context context = metricManager.startMessageReadTimer();
 
-        try {
+        try (Context ignored = metricManager.startMessageReadTimer()) {
             List<Long> messageList = getMessagesIdsForQueue(connection, queueName);
 
             if (!messageList.isEmpty()) {
@@ -192,15 +188,12 @@ class MessageCrudOperationsDao extends BaseDao {
             return messageMap.values();
         } catch (SQLException e) {
             throw new BrokerException("Error occurred while reading messages", e);
-        } finally {
-            context.stop();
         }
     }
 
     public Collection<Message> read(Connection connection, Map<Long, Message> messageMap) throws BrokerException {
-        Context context = metricManager.startMessageReadTimer();
 
-        try {
+        try (Context ignored = metricManager.startMessageReadTimer()) {
             if (!messageMap.isEmpty()) {
                 String idList = getSQLFormattedIdList(messageMap.size());
                 populateMessageWithMetadata(connection, idList, messageMap.keySet(), messageMap);
@@ -209,8 +202,6 @@ class MessageCrudOperationsDao extends BaseDao {
             return messageMap.values();
         } catch (SQLException e) {
             throw new BrokerException("Error occurred while reading messages", e);
-        } finally {
-            context.close();
         }
     }
 

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/impl/MessageDaoImpl.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/store/dao/impl/MessageDaoImpl.java
@@ -25,6 +25,7 @@ import org.wso2.broker.core.store.DbOperation;
 import org.wso2.broker.core.store.dao.MessageDao;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Implements functionality required to manage messages in persistence storage.
@@ -63,5 +64,9 @@ class MessageDaoImpl implements MessageDao {
                                                  "retrieving messages for queue " + queueName);
     }
 
-
+    @Override
+    public Collection<Message> read(Map<Long, Message> readList) throws BrokerException {
+        return crudOperationsDao.selectOperation(connection -> crudOperationsDao.read(connection, readList),
+                                                 "retrieving messages for delivery");
+    }
 }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/util/MessageTracer.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/util/MessageTracer.java
@@ -60,12 +60,17 @@ public final class MessageTracer {
         if (LOGGER.isTraceEnabled() && Objects.nonNull(message) && Objects.nonNull(queueHandler)) {
             Metadata metadata = message.getMetadata();
             String queueName = queueHandler.getQueue().getName();
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
-                                                          .routingKey(metadata.getRoutingKey())
-                                                          .exchangeName(metadata.getExchangeName())
-                                                          .redeliveryCount(message.getRedeliveryCount())
-                                                          .isRedelivered(message.isRedelivered())
-                                                          .queueName(queueName);
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId());
+
+            // Metadata can be null if we clear message when in-memory queue limit is exceeded
+            if (Objects.nonNull(metadata)) {
+                traceBuilder.routingKey(metadata.getRoutingKey())
+                            .exchangeName(metadata.getExchangeName());
+            }
+            traceBuilder.redeliveryCount(message.getRedeliveryCount())
+                        .isRedelivered(message.isRedelivered())
+                        .queueName(queueName);
+
             LOGGER.trace(traceBuilder.buildTrace(description));
         }
     }

--- a/modules/broker-core/src/main/java/org/wso2/broker/core/util/MessageTracer.java
+++ b/modules/broker-core/src/main/java/org/wso2/broker/core/util/MessageTracer.java
@@ -49,15 +49,9 @@ public final class MessageTracer {
 
     public static void trace(Message message, String description) {
         if (LOGGER.isTraceEnabled() && Objects.nonNull(message)) {
-            trace(message.getMetadata(), description);
-        }
-    }
-
-    public static void trace(Metadata metadata, String description) {
-        if (LOGGER.isTraceEnabled()) {
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(metadata.getInternalId())
-                                                          .routingKey(metadata.getRoutingKey())
-                                                          .exchangeName(metadata.getExchangeName());
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
+                                                          .routingKey(message.getMetadata().getRoutingKey())
+                                                          .exchangeName(message.getMetadata().getExchangeName());
             LOGGER.trace(traceBuilder.buildTrace(description));
         }
     }
@@ -66,7 +60,7 @@ public final class MessageTracer {
         if (LOGGER.isTraceEnabled() && Objects.nonNull(message) && Objects.nonNull(queueHandler)) {
             Metadata metadata = message.getMetadata();
             String queueName = queueHandler.getQueue().getName();
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(metadata.getInternalId())
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
                                                           .routingKey(metadata.getRoutingKey())
                                                           .exchangeName(metadata.getExchangeName())
                                                           .redeliveryCount(message.getRedeliveryCount())
@@ -82,7 +76,7 @@ public final class MessageTracer {
             Metadata metadata = message.getMetadata();
             String queueName = consumer.getQueueName();
             int id = consumer.getId();
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(metadata.getInternalId())
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
                                                           .queueName(queueName)
                                                           .consumerId(id)
                                                           .routingKey(metadata.getRoutingKey())
@@ -94,7 +88,7 @@ public final class MessageTracer {
     public static void trace(Message message, String description, TraceField... traceFields) {
         if (LOGGER.isTraceEnabled() && Objects.nonNull(message)) {
             Metadata metadata = message.getMetadata();
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(metadata.getInternalId())
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
                                                           .routingKey(metadata.getRoutingKey())
                                                           .exchangeName(metadata.getExchangeName())
                                                           .fieldList(Arrays.asList(traceFields));
@@ -103,10 +97,10 @@ public final class MessageTracer {
 
     }
 
-    public static void trace(Metadata metadata, String description, List<TraceField> traceFields) {
-        if (LOGGER.isTraceEnabled() && Objects.nonNull(metadata)) {
-            TraceBuilder traceBuilder = new TraceBuilder().internalId(metadata.getInternalId())
-                                                          .routingKey(metadata.getRoutingKey());
+    public static void trace(Message message, String description, List<TraceField> traceFields) {
+        if (LOGGER.isTraceEnabled() && Objects.nonNull(message)) {
+            TraceBuilder traceBuilder = new TraceBuilder().internalId(message.getInternalId())
+                                                          .routingKey(message.getMetadata().getRoutingKey());
 
             for (TraceField traceField : traceFields) {
                 traceBuilder.field(traceField);

--- a/modules/broker-core/src/test/java/org/wso2/broker/core/MessagingEngineTest.java
+++ b/modules/broker-core/src/test/java/org/wso2/broker/core/MessagingEngineTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import org.wso2.broker.common.ResourceNotFoundException;
 import org.wso2.broker.common.ValidationException;
 import org.wso2.broker.common.data.types.FieldTable;
+import org.wso2.broker.core.configuration.BrokerConfiguration;
 import org.wso2.broker.core.metrics.NullBrokerMetricManager;
 import org.wso2.broker.core.store.StoreFactory;
 
@@ -46,7 +47,7 @@ public class MessagingEngineTest {
     public void beforeTest() throws BrokerException, ValidationException {
         DataSource dataSource = DbUtil.getDataSource();
         NullBrokerMetricManager metricManager = new NullBrokerMetricManager();
-        StoreFactory storeFactory = new StoreFactory(dataSource, metricManager);
+        StoreFactory storeFactory = new StoreFactory(dataSource, metricManager, new BrokerConfiguration());
         messagingEngine = new MessagingEngine(storeFactory, metricManager);
     }
 

--- a/modules/broker-core/src/test/java/org/wso2/broker/core/TopicExchangeTest.java
+++ b/modules/broker-core/src/test/java/org/wso2/broker/core/TopicExchangeTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.broker.common.ValidationException;
 import org.wso2.broker.common.data.types.FieldTable;
+import org.wso2.broker.core.configuration.BrokerConfiguration;
 import org.wso2.broker.core.metrics.NullBrokerMetricManager;
 import org.wso2.broker.core.store.dao.impl.NoOpBindingDao;
 
@@ -58,7 +59,9 @@ public class TopicExchangeTest {
     @Test(dataProvider = "positiveTopicPairs", description = "Test positive topic matching")
     public void testPositiveSingleTopicMatching(String subscribedPattern,
                                                 String publishedTopic) throws BrokerException, ValidationException {
-        QueueHandlerFactory factory = new QueueHandlerFactory(null, new NullBrokerMetricManager());
+        QueueHandlerFactory factory = new QueueHandlerFactory(null,
+                                                              new NullBrokerMetricManager(),
+                                                              new BrokerConfiguration());
         QueueHandler handler = factory.createNonDurableQueueHandler(subscribedPattern, 10, false);
         topicExchange.bind(handler, subscribedPattern, FieldTable.EMPTY_TABLE);
 
@@ -75,7 +78,8 @@ public class TopicExchangeTest {
     @Test(dataProvider = "negativeTopicPairs", description = "Test negative topic matching")
     public void testNegativeSingleTopicMatching(String subscribedPattern,
                                                 String publishedTopic) throws BrokerException, ValidationException {
-        QueueHandlerFactory factory = new QueueHandlerFactory(null, new NullBrokerMetricManager());
+        QueueHandlerFactory factory = new QueueHandlerFactory(null, new NullBrokerMetricManager(),
+                                                              new BrokerConfiguration());
         QueueHandler handler = factory.createNonDurableQueueHandler(subscribedPattern, 10, false);
         topicExchange.bind(handler, subscribedPattern, FieldTable.EMPTY_TABLE);
 
@@ -87,7 +91,8 @@ public class TopicExchangeTest {
     @Test(dataProvider = "positiveTopicPairs", description = "Test topic removal")
     public void testTopicRemoval(String subscribedPattern, String publishedTopic)
             throws BrokerException, ValidationException {
-        QueueHandlerFactory factory = new QueueHandlerFactory(null, new NullBrokerMetricManager());
+        QueueHandlerFactory factory = new QueueHandlerFactory(null, new NullBrokerMetricManager(),
+                                                              new BrokerConfiguration());
         QueueHandler handler = factory.createNonDurableQueueHandler(subscribedPattern, 1000, false);
         Queue queue = handler.getQueue();
         topicExchange.bind(handler, subscribedPattern, FieldTable.EMPTY_TABLE);

--- a/modules/broker-core/src/test/java/org/wso2/broker/core/queue/QueueBufferTest.java
+++ b/modules/broker-core/src/test/java/org/wso2/broker/core/queue/QueueBufferTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.broker.core.queue;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.broker.core.Message;
+import org.wso2.broker.core.Metadata;
+
+public class QueueBufferTest {
+
+    private Metadata mockMetadata;
+    private QueueBuffer.MessageReader messageReader;
+
+    @BeforeClass
+    public void setUp() {
+        mockMetadata = new Metadata("queue1", "amq.direct", 0);
+        messageReader = (buffer, message) -> {
+            message.setMetadata(mockMetadata);
+            buffer.markMessageFilled(message);
+        };
+    }
+
+    @Test
+    public void testAdd() {
+        QueueBuffer queueBuffer = new QueueBuffer(10, messageReader);
+        for (int i = 0; i < 10; i++) {
+            Message message = new Message(i + 1, mockMetadata);
+            queueBuffer.add(message);
+            Assert.assertNotNull(message.getMetadata(), "Message data should not be cleared until the in-memory "
+                    + "limit is reached");
+        }
+
+        for (int i = 0; i < 3; i++) {
+            Message message = new Message(i + 1, mockMetadata);
+            queueBuffer.add(message);
+            Assert.assertNull(message.getMetadata(), "Message data should be cleared when the queue limit is reached");
+        }
+    }
+
+    @Test
+    public void testSize() {
+        QueueBuffer queueBuffer = new QueueBuffer(10, messageReader);
+        for (int i = 0; i < 12; i++) {
+            Message message = new Message(i + 1, mockMetadata);
+            queueBuffer.add(message);
+        }
+
+        Assert.assertEquals(queueBuffer.size(), 12, "Message size should match the number of added items");
+    }
+
+    @Test
+    public void testGetFirstDeliverable() throws Exception {
+        QueueBuffer queueBuffer = new QueueBuffer(10, messageReader);
+        for (int i = 0; i < 12; i++) {
+            Message message = new Message(i + 1, mockMetadata);
+            queueBuffer.add(message);
+        }
+
+        for (int i = 0; i < 12; i++) {
+            Message message = queueBuffer.getFirstDeliverable();
+            Assert.assertNotNull(message.getMetadata(), "Messages returned from #getFirstDeliverable() should never "
+                    + "be empty");
+            queueBuffer.remove(message);
+        }
+
+        Assert.assertEquals(queueBuffer.size(), 0, "Buffer size should be 0 after removing all messages");
+    }
+}

--- a/modules/broker-core/src/test/java/org/wso2/broker/core/store/DbEventMatcherTest.java
+++ b/modules/broker-core/src/test/java/org/wso2/broker/core/store/DbEventMatcherTest.java
@@ -59,8 +59,8 @@ public class DbEventMatcherTest {
             operationsList.add(DbOperation.getFactory().newInstance());
             TestOperationRequest request = testOperationsArray[i];
             if (request.beforeType == INSERT_MESSAGE) {
-                operationsList.get(i).insertMessage(new Message(
-                        new Metadata(request.messageId, "queue1", "amq.direct", 0)));
+                operationsList.get(i).insertMessage(new Message(request.messageId,
+                        new Metadata("queue1", "amq.direct", 0)));
             } else if (request.beforeType == DELETE_MESSAGE) {
                 operationsList.get(i).deleteMessage(request.messageId);
             } else {

--- a/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/QueueConsumerTest.java
+++ b/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/QueueConsumerTest.java
@@ -37,10 +37,31 @@ import javax.naming.InitialContext;
 
 public class QueueConsumerTest {
 
-    @Parameters({ "broker-port"})
+    /**
+     * Basic test to verify queue consumer producer functionality.
+     *
+     * @param port port of the broker
+     * @throws Exception if error
+     */
+    @Parameters({ "broker-port" })
     @Test
-    public void testConsumerProducerWithAutoAck(String port) throws Exception {
-        String queueName = "testConsumerProducerWithAutoAck";
+    public void testConsumerProducerWithAutoAckWith100(String port) throws Exception {
+        testConsumerProducerWithAutoAck(port, "testConsumerProducerWithAutoAck100", 100);
+    }
+
+    /**
+     * This will go beyond the configured in-memory queue limit.
+     *
+     * @param port port of the broker
+     * @throws Exception if error
+     */
+    @Parameters({ "broker-port" })
+    @Test
+    public void testConsumerProducerWithAutoAckWith1100(String port) throws Exception {
+        testConsumerProducerWithAutoAck(port, "testConsumerProducerWithAutoAck1100", 1100);
+    }
+
+    private void testConsumerProducerWithAutoAck(String port, String queueName, int numberOfMessages) throws Exception {
         InitialContext initialContextForQueue = ClientHelper
                 .getInitialContextBuilder("admin", "admin", "localhost", port)
                 .withQueue(queueName)
@@ -56,7 +77,6 @@ public class QueueConsumerTest {
         Queue queue = producerSession.createQueue(queueName);
         MessageProducer producer = producerSession.createProducer(queue);
 
-        int numberOfMessages = 100;
         for (int i = 0; i < numberOfMessages; i++) {
             producer.send(producerSession.createTextMessage("Test message " + i));
         }

--- a/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/SuiteInitializer.java
+++ b/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/SuiteInitializer.java
@@ -68,6 +68,7 @@ public class SuiteInitializer {
         TestConfigProvider configProvider = new TestConfigProvider();
 
         BrokerConfiguration brokerConfiguration = new BrokerConfiguration();
+        brokerConfiguration.setQueueInMemoryCacheLimit("1000");
         configProvider.registerConfigurationObject(BrokerConfiguration.NAMESPACE, brokerConfiguration);
 
         AmqpServerConfiguration serverConfiguration = new AmqpServerConfiguration();

--- a/modules/launcher/src/main/resources/broker.yaml
+++ b/modules/launcher/src/main/resources/broker.yaml
@@ -16,6 +16,10 @@
 
 # Broker Configurations.
 wso2.broker:
+ # Maximum number of messages cached in-memory for faster delivery. Increasing this number can result in better
+ # performance while increasing the memory consumption.
+ queueInMemoryCacheLimit: 10000
+
  # Datasource configurations used to communicate with the database.
  dataSource:
   # Database URL.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Currently, all the messages published to a queue is kept in the memory. We need to remove new messages from memory if queue size exceeds a certain limit and fetch them from DB if in-memory message count decreases. Otherwise, the broker can go out of memory.

Resolves #134

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Implement a new datastructure to release and load message data depending on the queue size.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

The message-queue reference information (queue attachment info) along with the message ordering for all the messages for a queue are kept in memory. This will not add much memory footprint since we are only keeping the message ID and the queue attachment info. Following is how the data structure works.

![message-spilling](https://user-images.githubusercontent.com/1148405/36082506-1e390f0c-0fd0-11e8-9e05-3b9c00f30617.png)


1. In each queue buffer, we will put message with message data until we reach the buffer limit. Then only the message ID and queue attachement information is stored in the queue buffer to avoid filling memory.
2. When one of the messages in the queue buffer is acknowledged we, will proceed the buffer limit cursor and send message data read requests to fill the message data.
3. When the message data is read from database and filled, the deliverable limit cursor will be progressed to make that message deliverable.

## User stories
> Summary of user stories addressed by this change>

N/A

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

* Performance improvement by loading and unloading messag data depending on queue size. 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

Tracked with #239

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests - 79%
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.