### PR TITLE
Use a new client connection to clear resources

### DIFF
--- a/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/amqp/NegativeQueueDeleteTest.java
+++ b/modules/integration/src/test/java/org/wso2/messaging/integration/standalone/amqp/NegativeQueueDeleteTest.java
@@ -68,12 +68,14 @@ public class NegativeQueueDeleteTest {
         channel.queueDelete(queueWithMessages, false, true);
     }
 
+    @Parameters({"broker-hostname", "broker-port", "admin-username", "admin-password"})
     @AfterMethod
-    public void tearDown() throws Exception {
-        Channel channel = amqpConnection.createChannel();
+    public void tearDown(String hostname, String port, String username, String password) throws Exception {
+        Connection connection = ClientHelper.getAmqpConnection(username, password, hostname, port);
+        Channel channel = connection.createChannel();
         channel.queueDelete(queueWithConsumers);
         channel.queueDelete(queueWithMessages);
-
-        amqpConnection.close();
+        connection.close();
+        this.amqpConnection.close();
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Client channel creation logic sends already existing channel ids after exceptions are thrown on previous operations of the tests. To avoid this a new connection is made for cleanup operations.
